### PR TITLE
Include investment model inputs sanity check routine

### DIFF
--- a/amiris_input_sanity_checker.ipynb
+++ b/amiris_input_sanity_checker.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d7ee448b",
+   "metadata": {},
+   "source": [
+    "# Sanity checker for inputs to AMIRIS\n",
+    "Notebook to inspect and check pommesinvest inputs as well as results that have been converted for usage in AMIRIS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50bb9720",
+   "metadata": {},
+   "source": [
+    "## Package imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df54e8c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pommesevaluation.amiris_input_sanity_check import (\n",
+    "    check_time_series, get_all_csv_files_in_folder_except\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32172b44",
+   "metadata": {},
+   "source": [
+    "## Workflow settings\n",
+    "Store all input files into a dict to iterate over"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd091f3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path_folder = \"./data_out/amiris/\"\n",
+    "scenario_subfolders = [\"none/\", \"5/\", \"50/\", \"95/\", \"all_scenarios/\"]\n",
+    "\n",
+    "files = {}\n",
+    "for scenario in scenario_subfolders:\n",
+    "    files[scenario] = [\n",
+    "        file for file in\n",
+    "        get_all_csv_files_in_folder_except(\n",
+    "            f\"{path_folder}{scenario}\", \n",
+    "            exception=[\n",
+    "                \"fixed_costs.csv\", \n",
+    "                \"ind_cluster_shift_only_country.csv\",\n",
+    "                \"ind_cluster_shift_only_from.csv\",\n",
+    "            ]\n",
+    "        )\n",
+    "        if not file.endswith(\"_2020.csv\")\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "831ee47c",
+   "metadata": {},
+   "source": [
+    "## Actual sanity checking\n",
+    "* Plot time series\n",
+    "* Display statistics of data sets using describe method\n",
+    "\n",
+    "Optically inspect for potential data bugs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23027146",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scen = \"none/\"\n",
+    "\n",
+    "for file in files[scen]:\n",
+    "    stats = check_time_series(path_folder=f\"{path_folder}{scen}\", file_name=file)\n",
+    "    display(stats)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b802e7d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scen = \"5/\"\n",
+    "\n",
+    "for file in files[scen]:\n",
+    "    stats = check_time_series(path_folder=f\"{path_folder}{scen}\", file_name=file)\n",
+    "    display(stats)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ad0e80e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scen = \"50/\"\n",
+    "\n",
+    "for file in files[scen]:\n",
+    "    stats = check_time_series(path_folder=f\"{path_folder}{scen}\", file_name=file)\n",
+    "    display(stats)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08f07d30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scen = \"95/\"\n",
+    "\n",
+    "for file in files[scen]:\n",
+    "    stats = check_time_series(path_folder=f\"{path_folder}{scen}\", file_name=file)\n",
+    "    display(stats)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "231181e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scen = \"all_scenarios/\"\n",
+    "\n",
+    "for file in files[scen]:\n",
+    "    stats = check_time_series(path_folder=f\"{path_folder}{scen}\", file_name=file)\n",
+    "    display(stats)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75592ec8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/invest_input_sanity_check.ipynb
+++ b/invest_input_sanity_check.ipynb
@@ -1,0 +1,752 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "554b9236",
+   "metadata": {},
+   "source": [
+    "# Investment model sanity check for inputs\n",
+    "This notebook seems to inspect all the inputs passed to _pommesinvest_ in order to inspect potential data bugs from\n",
+    "* visual inspection,\n",
+    "* analysis of some statistic moments,\n",
+    "* assert statements to check whether assumptions are valid."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb5280b8",
+   "metadata": {},
+   "source": [
+    "## Package imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f69c0863",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from pommesevaluation.pommesinvest_routines import InvestmentModelDummy, load_input_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb7bf33c",
+   "metadata": {},
+   "source": [
+    "## Parameter settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75f02b3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.rcParams.update({'font.size': 12})\n",
+    "\n",
+    "# Starting basis applied for all scenarios\n",
+    "path_folder_input = \"./model_inputs/pommesinvest/\"\n",
+    "start_time = \"2020-01-01 00:00:00\"\n",
+    "end_time = \"2045-12-31 23:00:00\"\n",
+    "freq = \"1H\"\n",
+    "overlap_in_time_steps = 0\n",
+    "countries = [\n",
+    "    \"AT\", \"BE\", \"CH\", \"CZ\", \"DE\", \"DK1\", \"DK2\", \"FR\", \"NL\", \n",
+    "    \"NO1\", \"NO2\", \"NO3\", \"NO4\", \"NO5\", \"PL\", \"SE1\", \"SE2\", \"SE3\", \"SE4\",\n",
+    "    \"IT\",\n",
+    "]\n",
+    "fuel_cost_pathway = \"NZE\"  # net zero emissions\n",
+    "fuel_price_shock = \"high\"\n",
+    "emissions_cost_pathway = \"long-term\"\n",
+    "activate_emissions_pathway_limit = True\n",
+    "activate_emissions_budget_limit = False\n",
+    "\n",
+    "# Parameters varying scenario-dependent\n",
+    "activate_demand_response = False\n",
+    "flexibility_options_scenario = \"50\"\n",
+    "demand_response_scenario = \"50\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "086e2ca1",
+   "metadata": {},
+   "source": [
+    "## Read in data sets\n",
+    "* Create an \"InvestmentModelDummy\" object, which holds some of the attributes of an InvestmentModel, but not really is one.\n",
+    "* Copy & paste methods from pommesinvest for reading in data to obtain the exact same data sets and make the data read in dependent on the configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eccdab1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im = InvestmentModelDummy(\n",
+    "    path_folder_input=path_folder_input,\n",
+    "    countries=countries,\n",
+    "    start_time=start_time,\n",
+    "    end_time=end_time,\n",
+    "    overlap_in_time_steps=overlap_in_time_steps,\n",
+    "    freq=freq,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c8a1d1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "buses = {\"buses\": \"buses\"}\n",
+    "\n",
+    "components = {\n",
+    "    \"sinks_excess\": \"sinks_excess\",\n",
+    "    \"sinks_demand_el\": \"sinks_demand_el\",\n",
+    "    \"sources_shortage\": \"sources_shortage\",\n",
+    "    \"sources_commodity\": \"sources_commodity\",\n",
+    "    \"sources_renewables\": \"sources_renewables_investment_model\",\n",
+    "    \"exogenous_storages_el\": \"storages_el_exogenous\",\n",
+    "    \"new_built_storages_el\": \"storages_el_investment_options\",\n",
+    "    \"exogenous_transformers\": \"transformers_exogenous\",\n",
+    "    \"new_built_transformers\": \"transformers_investment_options\",\n",
+    "}\n",
+    "\n",
+    "hourly_time_series = {\n",
+    "    \"sinks_demand_el_ts\": \"sinks_demand_el_ts_hourly\",\n",
+    "    \"sources_renewables_ts\": \"sources_renewables_ts_hourly\",\n",
+    "    \"transformers_minload_ts\": \"transformers_minload_ts_hourly\",\n",
+    "    \"transformers_availability_ts\": \"transformers_availability_ts_hourly\",\n",
+    "    \"linking_transformers_ts\": \"linking_transformers_ts\",\n",
+    "}\n",
+    "\n",
+    "annual_time_series = {\n",
+    "    \"transformers_exogenous_max_ts\": \"transformers_exogenous_max_ts\",\n",
+    "    \"costs_fuel_ts\": (\n",
+    "        f\"costs_fuel_{fuel_cost_pathway}_{fuel_price_shock}_nominal_indexed_ts\"\n",
+    "    ),\n",
+    "    \"costs_emissions_ts\": (\n",
+    "        f\"costs_emissions_{emissions_cost_pathway}_nominal_indexed_ts\"\n",
+    "    ),\n",
+    "    \"costs_operation_ts\": (\n",
+    "        f\"variable_costs_{flexibility_options_scenario}%_nominal\"\n",
+    "    ),\n",
+    "    \"costs_operation_storages_ts\": (\n",
+    "        f\"variable_costs_storages_{flexibility_options_scenario}%_nominal\"\n",
+    "    ),\n",
+    "    \"costs_investment\": (\n",
+    "        f\"investment_expenses_{flexibility_options_scenario}%_nominal\"\n",
+    "    ),\n",
+    "    \"costs_storages_investment_capacity\": (\n",
+    "        f\"investment_expenses_storages_capacity_{flexibility_options_scenario}%_nominal\"\n",
+    "    ),\n",
+    "    \"costs_storages_investment_power\": (\n",
+    "        f\"investment_expenses_storages_power_{flexibility_options_scenario}%_nominal\"\n",
+    "    ),\n",
+    "    \"linking_transformers_annual_ts\": \"linking_transformers_annual_ts\",\n",
+    "    \"storages_el_exogenous_max_ts\": \"storages_el_exogenous_max_ts\",\n",
+    "}\n",
+    "\n",
+    "# Time-invariant data sets\n",
+    "other_files = {\n",
+    "    \"emission_limits\": \"emission_limits\",\n",
+    "    \"wacc\": \"wacc\",\n",
+    "    \"interest_rate\": \"interest_rate\",\n",
+    "    \"fixed_costs\": (\n",
+    "        f\"fixed_costs_{flexibility_options_scenario}%_nominal\"\n",
+    "    ),\n",
+    "    \"fixed_costs_storages\": (\n",
+    "        f\"fixed_costs_storages_{flexibility_options_scenario}%_nominal\"\n",
+    "    ),\n",
+    "    \"hydrogen_investment_maxima\": \"hydrogen_investment_maxima\",\n",
+    "    \"linking_transformers\": \"linking_transformers\",\n",
+    "}\n",
+    "\n",
+    "# Development factors for emissions; used for scaling minimum loads\n",
+    "if (\n",
+    "    activate_emissions_pathway_limit\n",
+    "    or activate_emissions_budget_limit\n",
+    "):\n",
+    "    other_files[\n",
+    "        \"emission_development_factors\"\n",
+    "    ] = \"emission_development_factors\"\n",
+    "\n",
+    "# Add demand response units\n",
+    "if activate_demand_response:\n",
+    "    # Overall demand = overall demand excluding demand response baseline\n",
+    "    hourly_time_series[\"sinks_demand_el_ts\"] = (\n",
+    "        f\"sinks_demand_el_excl_demand_response_ts_{im.demand_response_scenario}_hourly\"\n",
+    "    )\n",
+    "    components[\"sinks_demand_el\"] = (\n",
+    "        f\"sinks_demand_el_excl_demand_response_{im.demand_response_scenario}\"\n",
+    "    )\n",
+    "\n",
+    "    # Obtain demand response clusters from file to avoid hard-coding\n",
+    "    components[\n",
+    "        \"demand_response_clusters_eligibility\"\n",
+    "    ] = \"demand_response_clusters_eligibility\"\n",
+    "    dr_clusters = load_input_data(\n",
+    "        filename=\"demand_response_clusters_eligibility\", im=im\n",
+    "    )\n",
+    "    # Add demand response clusters information to the model itself\n",
+    "    im.add_demand_response_clusters(list(dr_clusters.index))\n",
+    "    for dr_cluster in dr_clusters.index:\n",
+    "        components[f\"sinks_dr_el_{dr_cluster}\"] = (\n",
+    "            f\"{dr_cluster}_potential_parameters_{im.demand_response_scenario}%\"\n",
+    "        )\n",
+    "        annual_time_series[f\"sinks_dr_el_{dr_cluster}_variable_costs\"] = (\n",
+    "            f\"{dr_cluster}_variable_costs_parameters_{im.demand_response_scenario}%\"\n",
+    "        )\n",
+    "        annual_time_series[\n",
+    "            f\"sinks_dr_el_{dr_cluster}_fixed_costs_and_investments\"\n",
+    "        ] = (\n",
+    "            f\"{dr_cluster}_fixed_costs_and_investments_parameters_{im.demand_response_scenario}%\"\n",
+    "        )\n",
+    "\n",
+    "    hourly_time_series[\n",
+    "        \"sinks_dr_el_ts\"\n",
+    "    ] = f\"sinks_demand_response_el_ts_{im.demand_response_scenario}\"\n",
+    "\n",
+    "    hourly_time_series[\"sinks_dr_el_ava_pos_ts\"] = (\n",
+    "        f\"sinks_demand_response_el_ava_pos_ts_{im.demand_response_scenario}\"\n",
+    "    )\n",
+    "    hourly_time_series[\"sinks_dr_el_ava_neg_ts\"] = (\n",
+    "        f\"sinks_demand_response_el_ava_neg_ts_{im.demand_response_scenario}\"\n",
+    "    )\n",
+    "\n",
+    "# Combine all files\n",
+    "input_files = {\n",
+    "    **buses,\n",
+    "    **components,\n",
+    "    **annual_time_series,\n",
+    "    **hourly_time_series,\n",
+    "}\n",
+    "input_files = {**input_files, **other_files}\n",
+    "\n",
+    "input_data = {\n",
+    "    key: load_input_data(filename=name, im=im)\n",
+    "    for key, name in input_files.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d84fc3d2",
+   "metadata": {},
+   "source": [
+    "# Check data sanity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "863e387f",
+   "metadata": {},
+   "source": [
+    "## Buses\n",
+    "Assertion statements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "229e9a5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "buses = input_data[\"buses\"]\n",
+    "\n",
+    "display(buses.head(10))\n",
+    "display(buses.tail(10))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ad1f5fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "buses.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7c1092b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check_countries = (buses.index.str.split(\"_\", 1, expand=True).get_level_values(0) == buses[\"country\"]).all()\n",
+    "assert check_countries == True, f\"Expected False, but result was {to_check}\"\n",
+    "\n",
+    "bus_names = set(buses.index.str.split(\"_\", expand=True).get_level_values(1))\n",
+    "assert bus_names == {\"bus\"}, f\"Expected 'bus' as the only name, but result was {bus_names}\"\n",
+    "\n",
+    "bus_commodities = set(buses.index.str.rsplit(\"_\", 1, expand=True).get_level_values(1))\n",
+    "all_commodities = {\n",
+    "    'el', 'biomass', 'hardcoal', 'hydro', 'hydrogen', \n",
+    "    'lignite', 'mixedfuels', 'natgas', 'oil', 'otherfossil',\n",
+    "    'solarPV', 'uranium', 'waste', 'windoffshore', 'windonshore'\n",
+    "}\n",
+    "assert bus_commodities == all_commodities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f39325f5",
+   "metadata": {},
+   "source": [
+    "## Sinks\n",
+    "### Excess Sinks\n",
+    "Only visual inspection sufficient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7b305a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_excess = input_data[\"sinks_excess\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93b12aaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_excess"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d99db2f1",
+   "metadata": {},
+   "source": [
+    "### Demand sinks\n",
+    "* Should contain maximum values as of 2020\n",
+    "* Visual inspection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f096b825",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demand = input_data[\"sinks_demand_el\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dae9cae2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demand"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0cf504c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(16, 10))\n",
+    "_ = demand[\"maximum\"].sort_values(ascending=False).plot(kind=\"bar\", ax=ax)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52af0406",
+   "metadata": {},
+   "source": [
+    "## Sources\n",
+    "### Shortage sources\n",
+    "Only visual inspection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfd1625e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shortage = input_data[\"sources_shortage\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2cace88a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shortage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d4b2101",
+   "metadata": {},
+   "source": [
+    "### Commodity sources\n",
+    "Only visual inspection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92e82986",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "commodities = input_data[\"sources_commodity\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a52318c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "commodities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64907b19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fuels = commodities.index.str.rsplit(\"_\", 1, expand=True).get_level_values(1).unique()\n",
+    "for fuel in fuels:\n",
+    "    display(commodities.loc[commodities.index.str.contains(fuel)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4297c8e",
+   "metadata": {},
+   "source": [
+    "### Renewable sources\n",
+    "* Visual inspection\n",
+    "* Statistical moments of data set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ca941f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "renewables = input_data[\"sources_renewables\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbb44c44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(renewables.head(10))\n",
+    "display(renewables.tail(10))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b34e52eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hydro values are in kWh/h and reflect the inflow potential; thus therefore are not comparable!\n",
+    "hydro = renewables.loc[renewables.index.str.contains(\"_hydro\")]\n",
+    "non_hydro_renewables = renewables.loc[~(renewables.index.str.contains(\"_hydro\"))]\n",
+    "print(\"Hydro\")\n",
+    "display(hydro.describe())\n",
+    "print(\"Remaining RES\")\n",
+    "display(non_hydro_renewables.describe())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2db43ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(2, 1, figsize=(16, 16))\n",
+    "_ = hydro[\"capacity\"].sort_values(ascending=False).plot(kind=\"bar\", ax=ax[0])\n",
+    "_ = non_hydro_renewables[\"capacity\"].sort_values(ascending=False).plot(kind=\"bar\", ax=ax[1])\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67ee13da",
+   "metadata": {},
+   "source": [
+    "### Exogenous storages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "935b3ad0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exogenous_storages = input_data[\"exogenous_storages_el\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f5ff8d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exogenous_storages.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19b6b4f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phes = exogenous_storages.loc[exogenous_storages[\"type\"] == \"phes\"]\n",
+    "reservoir = exogenous_storages.loc[exogenous_storages[\"type\"] == \"reservoir\"]\n",
+    "print(\"PHES\")\n",
+    "display(phes.iloc[:,:15].describe())\n",
+    "display(phes.iloc[:,15:].describe())\n",
+    "print(\"Reservoir\")\n",
+    "display(reservoir.iloc[:,:15].describe())\n",
+    "display(reservoir.iloc[:,15:].describe())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5632d12",
+   "metadata": {},
+   "source": [
+    "### New-built storages\n",
+    "Only visual inspection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c457e3bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_storages = input_data[\"new_built_storages_el\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd869e6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_storages.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56dcbacb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_storages.iloc[:,:15]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f93ef0ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_storages.iloc[:,15:]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9af49f3f",
+   "metadata": {},
+   "source": [
+    "## Transformers\n",
+    "### Exogenous transformers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dacbb651",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exogenous_transformers = input_data[\"exogenous_transformers\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f499a8d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exogenous_transformers.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bbdd077",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(exogenous_transformers.iloc[:,:15].head(10))\n",
+    "display(exogenous_transformers.iloc[:,15:30].head(10))\n",
+    "display(exogenous_transformers.iloc[:,30:45].head(10))\n",
+    "display(exogenous_transformers.iloc[:,45:].head(10))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ac3bf05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exogenous_transformers.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cc2642e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(exogenous_transformers.iloc[:,:15].describe())\n",
+    "display(exogenous_transformers.iloc[:,15:30].describe())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fc49306",
+   "metadata": {},
+   "source": [
+    "### New-built transformers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27ee54e5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c0152ed",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/invest_input_sanity_check.ipynb
+++ b/invest_input_sanity_check.ipynb
@@ -30,7 +30,8 @@
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from pommesevaluation.pommesinvest_routines import InvestmentModelDummy, load_input_data"
+    "from pommesevaluation.pommesinvest_routines import InvestmentModelDummy, load_input_data\n",
+    "from pommesevaluation.investment_results_inspection import plot_time_series_cols"
    ]
   },
   {
@@ -240,17 +241,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d84fc3d2",
-   "metadata": {},
-   "source": [
-    "# Check data sanity"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "863e387f",
    "metadata": {},
    "source": [
+    "# Components\n",
+    "\n",
     "## Buses\n",
     "Assertion statements"
    ]
@@ -477,6 +472,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f1f9bbab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "renewables.loc[[\"FR_source_windoffshore\", \"IT_source_windoffshore\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "b34e52eb",
    "metadata": {},
    "outputs": [],
@@ -678,9 +683,194 @@
    "source": []
   },
   {
+   "cell_type": "markdown",
+   "id": "5ff90071",
+   "metadata": {},
+   "source": [
+    "# Timeseries\n",
+    "## Demand"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c0152ed",
+   "id": "c852c2f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_demand_el_ts = input_data[\"sinks_demand_el_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dccef6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_demand_el_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1f6a7c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(sinks_demand_el_ts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16038b42",
+   "metadata": {},
+   "source": [
+    "## RES generation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f12f54a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_renewables_ts = input_data[\"sources_renewables_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "064179b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_renewables_ts.iloc[:,:15].describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f73a01bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_renewables_ts.iloc[:,15:30].describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4a17c71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_renewables_ts.iloc[:,30:45].describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20391a32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_renewables_ts.iloc[:,45:60].describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "643875bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(sources_renewables_ts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fa6f964",
+   "metadata": {},
+   "source": [
+    "## Transformers\n",
+    "### Minimum loads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbf3f90c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_loads_ts = input_data[\"transformers_minload_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99e30cfb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_loads_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f63fd2f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(min_loads_ts[:8760])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a3496cb",
+   "metadata": {},
+   "source": [
+    "### Availability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b13926e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "availability_ts = input_data[\"transformers_availability_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d530b16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "availability_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20fba0dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = availability_ts[:8760].plot()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64fe6992",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -713,7 +903,12 @@
    "title_cell": "Table of Contents",
    "title_sidebar": "Contents",
    "toc_cell": false,
-   "toc_position": {},
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "512px"
+   },
    "toc_section_display": true,
    "toc_window_display": true
   },

--- a/invest_input_sanity_check.ipynb
+++ b/invest_input_sanity_check.ipynb
@@ -30,8 +30,12 @@
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from pommesevaluation.pommesinvest_routines import InvestmentModelDummy, load_input_data\n",
-    "from pommesevaluation.investment_results_inspection import plot_time_series_cols"
+    "from pommesevaluation.pommesinvest_routines import (\n",
+    "    InvestmentModelDummy, load_input_data, process_input_data, resample_timeseries\n",
+    ")\n",
+    "from pommesevaluation.investment_results_inspection import (\n",
+    "    plot_time_series_cols, create_datetime_index\n",
+    ")"
    ]
   },
   {
@@ -98,6 +102,14 @@
     "    end_time=end_time,\n",
     "    overlap_in_time_steps=overlap_in_time_steps,\n",
     "    freq=freq,\n",
+    "    fuel_cost_pathway=fuel_cost_pathway,\n",
+    "    fuel_price_shock=fuel_price_shock,\n",
+    "    emissions_cost_pathway=emissions_cost_pathway,\n",
+    "    flexibility_options_scenario=flexibility_options_scenario,\n",
+    "    activate_emissions_pathway_limit=activate_emissions_pathway_limit,\n",
+    "    activate_emissions_budget_limit=activate_emissions_budget_limit,\n",
+    "    activate_demand_response=activate_demand_response,\n",
+    "    demand_response_scenario=demand_response_scenario\n",
     ")"
    ]
   },
@@ -108,135 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "buses = {\"buses\": \"buses\"}\n",
-    "\n",
-    "components = {\n",
-    "    \"sinks_excess\": \"sinks_excess\",\n",
-    "    \"sinks_demand_el\": \"sinks_demand_el\",\n",
-    "    \"sources_shortage\": \"sources_shortage\",\n",
-    "    \"sources_commodity\": \"sources_commodity\",\n",
-    "    \"sources_renewables\": \"sources_renewables_investment_model\",\n",
-    "    \"exogenous_storages_el\": \"storages_el_exogenous\",\n",
-    "    \"new_built_storages_el\": \"storages_el_investment_options\",\n",
-    "    \"exogenous_transformers\": \"transformers_exogenous\",\n",
-    "    \"new_built_transformers\": \"transformers_investment_options\",\n",
-    "}\n",
-    "\n",
-    "hourly_time_series = {\n",
-    "    \"sinks_demand_el_ts\": \"sinks_demand_el_ts_hourly\",\n",
-    "    \"sources_renewables_ts\": \"sources_renewables_ts_hourly\",\n",
-    "    \"transformers_minload_ts\": \"transformers_minload_ts_hourly\",\n",
-    "    \"transformers_availability_ts\": \"transformers_availability_ts_hourly\",\n",
-    "    \"linking_transformers_ts\": \"linking_transformers_ts\",\n",
-    "}\n",
-    "\n",
-    "annual_time_series = {\n",
-    "    \"transformers_exogenous_max_ts\": \"transformers_exogenous_max_ts\",\n",
-    "    \"costs_fuel_ts\": (\n",
-    "        f\"costs_fuel_{fuel_cost_pathway}_{fuel_price_shock}_nominal_indexed_ts\"\n",
-    "    ),\n",
-    "    \"costs_emissions_ts\": (\n",
-    "        f\"costs_emissions_{emissions_cost_pathway}_nominal_indexed_ts\"\n",
-    "    ),\n",
-    "    \"costs_operation_ts\": (\n",
-    "        f\"variable_costs_{flexibility_options_scenario}%_nominal\"\n",
-    "    ),\n",
-    "    \"costs_operation_storages_ts\": (\n",
-    "        f\"variable_costs_storages_{flexibility_options_scenario}%_nominal\"\n",
-    "    ),\n",
-    "    \"costs_investment\": (\n",
-    "        f\"investment_expenses_{flexibility_options_scenario}%_nominal\"\n",
-    "    ),\n",
-    "    \"costs_storages_investment_capacity\": (\n",
-    "        f\"investment_expenses_storages_capacity_{flexibility_options_scenario}%_nominal\"\n",
-    "    ),\n",
-    "    \"costs_storages_investment_power\": (\n",
-    "        f\"investment_expenses_storages_power_{flexibility_options_scenario}%_nominal\"\n",
-    "    ),\n",
-    "    \"linking_transformers_annual_ts\": \"linking_transformers_annual_ts\",\n",
-    "    \"storages_el_exogenous_max_ts\": \"storages_el_exogenous_max_ts\",\n",
-    "}\n",
-    "\n",
-    "# Time-invariant data sets\n",
-    "other_files = {\n",
-    "    \"emission_limits\": \"emission_limits\",\n",
-    "    \"wacc\": \"wacc\",\n",
-    "    \"interest_rate\": \"interest_rate\",\n",
-    "    \"fixed_costs\": (\n",
-    "        f\"fixed_costs_{flexibility_options_scenario}%_nominal\"\n",
-    "    ),\n",
-    "    \"fixed_costs_storages\": (\n",
-    "        f\"fixed_costs_storages_{flexibility_options_scenario}%_nominal\"\n",
-    "    ),\n",
-    "    \"hydrogen_investment_maxima\": \"hydrogen_investment_maxima\",\n",
-    "    \"linking_transformers\": \"linking_transformers\",\n",
-    "}\n",
-    "\n",
-    "# Development factors for emissions; used for scaling minimum loads\n",
-    "if (\n",
-    "    activate_emissions_pathway_limit\n",
-    "    or activate_emissions_budget_limit\n",
-    "):\n",
-    "    other_files[\n",
-    "        \"emission_development_factors\"\n",
-    "    ] = \"emission_development_factors\"\n",
-    "\n",
-    "# Add demand response units\n",
-    "if activate_demand_response:\n",
-    "    # Overall demand = overall demand excluding demand response baseline\n",
-    "    hourly_time_series[\"sinks_demand_el_ts\"] = (\n",
-    "        f\"sinks_demand_el_excl_demand_response_ts_{im.demand_response_scenario}_hourly\"\n",
-    "    )\n",
-    "    components[\"sinks_demand_el\"] = (\n",
-    "        f\"sinks_demand_el_excl_demand_response_{im.demand_response_scenario}\"\n",
-    "    )\n",
-    "\n",
-    "    # Obtain demand response clusters from file to avoid hard-coding\n",
-    "    components[\n",
-    "        \"demand_response_clusters_eligibility\"\n",
-    "    ] = \"demand_response_clusters_eligibility\"\n",
-    "    dr_clusters = load_input_data(\n",
-    "        filename=\"demand_response_clusters_eligibility\", im=im\n",
-    "    )\n",
-    "    # Add demand response clusters information to the model itself\n",
-    "    im.add_demand_response_clusters(list(dr_clusters.index))\n",
-    "    for dr_cluster in dr_clusters.index:\n",
-    "        components[f\"sinks_dr_el_{dr_cluster}\"] = (\n",
-    "            f\"{dr_cluster}_potential_parameters_{im.demand_response_scenario}%\"\n",
-    "        )\n",
-    "        annual_time_series[f\"sinks_dr_el_{dr_cluster}_variable_costs\"] = (\n",
-    "            f\"{dr_cluster}_variable_costs_parameters_{im.demand_response_scenario}%\"\n",
-    "        )\n",
-    "        annual_time_series[\n",
-    "            f\"sinks_dr_el_{dr_cluster}_fixed_costs_and_investments\"\n",
-    "        ] = (\n",
-    "            f\"{dr_cluster}_fixed_costs_and_investments_parameters_{im.demand_response_scenario}%\"\n",
-    "        )\n",
-    "\n",
-    "    hourly_time_series[\n",
-    "        \"sinks_dr_el_ts\"\n",
-    "    ] = f\"sinks_demand_response_el_ts_{im.demand_response_scenario}\"\n",
-    "\n",
-    "    hourly_time_series[\"sinks_dr_el_ava_pos_ts\"] = (\n",
-    "        f\"sinks_demand_response_el_ava_pos_ts_{im.demand_response_scenario}\"\n",
-    "    )\n",
-    "    hourly_time_series[\"sinks_dr_el_ava_neg_ts\"] = (\n",
-    "        f\"sinks_demand_response_el_ava_neg_ts_{im.demand_response_scenario}\"\n",
-    "    )\n",
-    "\n",
-    "# Combine all files\n",
-    "input_files = {\n",
-    "    **buses,\n",
-    "    **components,\n",
-    "    **annual_time_series,\n",
-    "    **hourly_time_series,\n",
-    "}\n",
-    "input_files = {**input_files, **other_files}\n",
-    "\n",
-    "input_data = {\n",
-    "    key: load_input_data(filename=name, im=im)\n",
-    "    for key, name in input_files.items()\n",
-    "}"
+    "input_data = process_input_data(im)"
    ]
   },
   {
@@ -342,7 +226,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "demand = input_data[\"sinks_demand_el\"]"
+    "sinks_demand_el = input_data[\"sinks_demand_el\"]"
    ]
   },
   {
@@ -352,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "demand"
+    "sinks_demand_el"
    ]
   },
   {
@@ -363,7 +247,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(16, 10))\n",
-    "_ = demand[\"maximum\"].sort_values(ascending=False).plot(kind=\"bar\", ax=ax)\n",
+    "_ = sinks_demand_el[\"maximum\"].sort_values(ascending=False).plot(kind=\"bar\", ax=ax)\n",
     "plt.show()"
    ]
   },
@@ -684,7 +568,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9fa6363",
+   "id": "656a29ce",
    "metadata": {},
    "source": [
     "## Linking transformers"
@@ -693,7 +577,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44d430bd",
+   "id": "826e6637",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -703,7 +587,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a5b25c7",
+   "id": "743617e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -713,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1cb398b6",
+   "id": "d33ccecf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -723,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cfe123f",
+   "id": "441f9fa5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -733,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d68e2374",
+   "id": "908ce0de",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -780,6 +664,31 @@
    "outputs": [],
    "source": [
     "plot_time_series_cols(sinks_demand_el_ts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a789caa8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_demand_el_ts_absolute = pd.DataFrame(\n",
+    "    index=sinks_demand_el_ts.index,\n",
+    "    columns=sinks_demand_el_ts.columns\n",
+    ")\n",
+    "for col in sinks_demand_el_ts.columns:\n",
+    "    sinks_demand_el_ts_absolute[col] = sinks_demand_el_ts[col] * sinks_demand_el.at[col, \"maximum\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03492245",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(sinks_demand_el_ts_absolute)"
    ]
   },
   {
@@ -1315,7 +1224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0420a955",
+   "id": "a2baffb5",
    "metadata": {},
    "source": [
     "### Fixed costs"
@@ -1324,7 +1233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8596c96b",
+   "id": "ec23c172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1334,7 +1243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47280915",
+   "id": "e700ff1f",
    "metadata": {
     "scrolled": true
    },
@@ -1346,7 +1255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0c2f292",
+   "id": "9c2527e3",
    "metadata": {
     "scrolled": true
    },
@@ -1358,7 +1267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33210f9d",
+   "id": "7e8c6f73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1370,7 +1279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7ec36ea2",
+   "id": "c370b548",
    "metadata": {
     "scrolled": false
    },
@@ -1382,7 +1291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f476113",
+   "id": "c694252a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1391,7 +1300,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ddff209",
+   "id": "294e33a1",
    "metadata": {},
    "source": [
     "### Fixed costs storages"
@@ -1400,7 +1309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4cb9e4b1",
+   "id": "b5303193",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1410,7 +1319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9db429f",
+   "id": "57ad3863",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1420,7 +1329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32414316",
+   "id": "2af489ef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1429,7 +1338,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a6732c2",
+   "id": "c913b39a",
    "metadata": {},
    "source": [
     "#### Fixed costs for capacity"
@@ -1438,7 +1347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "249c1f0e",
+   "id": "daa24b70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1448,7 +1357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79fa0626",
+   "id": "3e3876af",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1468,7 +1377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "630eb1c6",
+   "id": "04ffb4e5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1478,7 +1387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0541634",
+   "id": "51eca968",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1487,7 +1396,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c89d862",
+   "id": "4a1a96ed",
    "metadata": {},
    "source": [
     "#### Fixed costs for power"
@@ -1496,7 +1405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c179a3d",
+   "id": "623d5126",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1542,7 +1451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e824871",
+   "id": "d4144d39",
    "metadata": {},
    "source": [
     "## Emission limits"
@@ -1551,7 +1460,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47763fd8",
+   "id": "b44c9ec7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1561,7 +1470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0a166d7",
+   "id": "4ec5f35f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1571,7 +1480,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e806240",
+   "id": "1955a69b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1580,7 +1489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f04ccccb",
+   "id": "9592175d",
    "metadata": {},
    "source": [
     "# Other data\n",
@@ -1590,7 +1499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a791abed",
+   "id": "ff4c95c6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1600,7 +1509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46b66bf1",
+   "id": "2d5f3cc7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1610,7 +1519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce76c187",
+   "id": "69320b76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1619,7 +1528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb4b3ed4",
+   "id": "a41fdb52",
    "metadata": {},
    "source": [
     "## Interest rate"
@@ -1628,7 +1537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f4ee5a4",
+   "id": "1de6b34b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1638,7 +1547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1be723a",
+   "id": "30b0ab59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1648,7 +1557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61dbc2e0",
+   "id": "3673d3fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1657,7 +1566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32df9aa9",
+   "id": "fe4aaeb9",
    "metadata": {},
    "source": [
     "## Hydrogen investment maxima"
@@ -1666,7 +1575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d34bc945",
+   "id": "a4946ab1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1676,7 +1585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "625d9863",
+   "id": "8ce3a106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1686,7 +1595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b5c246a",
+   "id": "f2945f2f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1696,7 +1605,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88aa0327",
+   "id": "0fc59845",
    "metadata": {},
    "source": [
     "## Emission development factors"
@@ -1705,7 +1614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3707c128",
+   "id": "279a95ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1715,7 +1624,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2be29bdf",
+   "id": "c6b5dadd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1725,7 +1634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d934e8b",
+   "id": "5d0a81e6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1733,9 +1642,404 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6b786d6d",
+   "metadata": {},
+   "source": [
+    "# Demand Response data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82f660b1",
+   "id": "4594fe9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "activate_demand_response = True\n",
+    "im.activate_demand_response = activate_demand_response\n",
+    "\n",
+    "input_data = process_input_data(im)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff6b463b",
+   "metadata": {},
+   "source": [
+    "## Demand"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e68490a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_demand_el_ts = input_data[\"sinks_demand_el_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3556d72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_demand_el_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e915c944",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(sinks_demand_el_ts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f5329a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_demand_el = input_data[\"sinks_demand_el\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b03fadf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_demand_el"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6090e022",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_demand_el_ts_absolute = pd.DataFrame(\n",
+    "    index=sinks_demand_el_ts.index,\n",
+    "    columns=sinks_demand_el_ts.columns\n",
+    ")\n",
+    "for col in sinks_demand_el_ts.columns:\n",
+    "    sinks_demand_el_ts_absolute[col] = sinks_demand_el_ts[col] * sinks_demand_el.at[col, \"maximum\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4c4ff48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(sinks_demand_el_ts_absolute)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "655d1123",
+   "metadata": {},
+   "source": [
+    "## Eligibility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1282e4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dr_clusters = load_input_data(\n",
+    "    filename=\"demand_response_clusters_eligibility\", im=im\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08f4cbe2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dr_clusters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7925da3c",
+   "metadata": {},
+   "source": [
+    "## Potential parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58fd0bf6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "potential_parameters = {}\n",
+    "for dr_cluster in dr_clusters.index:\n",
+    "    potential_parameters[dr_cluster] = input_data[f\"sinks_dr_el_{dr_cluster}\"]\n",
+    "    print(\"*\" * 50)\n",
+    "    print(dr_cluster)\n",
+    "    print(\"*\" * 50)\n",
+    "    plot_time_series_cols(potential_parameters[dr_cluster])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e7886a7",
+   "metadata": {},
+   "source": [
+    "## Variable costs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d393176",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variable_costs_parameters = {}\n",
+    "for dr_cluster in dr_clusters.index:\n",
+    "    variable_costs_parameters[dr_cluster] = input_data[f\"sinks_dr_el_{dr_cluster}_variable_costs\"]\n",
+    "    print(\"*\" * 50)\n",
+    "    print(dr_cluster)\n",
+    "    print(\"*\" * 50)\n",
+    "    plot_time_series_cols(variable_costs_parameters[dr_cluster])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63768086",
+   "metadata": {},
+   "source": [
+    "## Investment expenses and fixed costs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a233827",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_costs_parameters = {}\n",
+    "for dr_cluster in dr_clusters.index:\n",
+    "    fixed_costs_parameters[dr_cluster] = input_data[f\"sinks_dr_el_{dr_cluster}_fixed_costs_and_investments\"]\n",
+    "    print(\"*\" * 50)\n",
+    "    print(dr_cluster)\n",
+    "    print(\"*\" * 50)\n",
+    "    plot_time_series_cols(fixed_costs_parameters[dr_cluster])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c8fe34c",
+   "metadata": {},
+   "source": [
+    "## Demand Response baseline consumption"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8495955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_dr_el_ts = input_data[\"sinks_dr_el_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b554fec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_dr_el_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02d48c87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(sinks_dr_el_ts[:8760])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72d1db59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_dr_el_ts_absolute = {}\n",
+    "for dr_cluster in dr_clusters.index:\n",
+    "    df = create_datetime_index(potential_parameters[dr_cluster].loc[:,[\"max_cap\"]])\n",
+    "    df = resample_timeseries(\n",
+    "        df, freq, aggregation_rule=\"sum\", interpolation_rule=\"ffill\"\n",
+    "    )[:-1]\n",
+    "    sinks_dr_el_ts_absolute[dr_cluster] = sinks_dr_el_ts[dr_cluster] * df[\"max_cap\"].values\n",
+    "    fig, ax = plt.subplots(figsize=(15, 5))\n",
+    "    _ = sinks_dr_el_ts_absolute[dr_cluster].plot(ax=ax)\n",
+    "    plt.title(dr_cluster)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eec9c384",
+   "metadata": {},
+   "source": [
+    "## Availabilty positive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26fb9334",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_dr_el_ava_pos_ts = input_data[\"sinks_dr_el_ava_pos_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66166760",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_dr_el_ava_pos_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1036f11d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(sinks_dr_el_ava_pos_ts[:8760])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75a20704",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_dr_el_ava_pos_ts_absolute = {}\n",
+    "for dr_cluster in dr_clusters.index:\n",
+    "    df = create_datetime_index(\n",
+    "        potential_parameters[dr_cluster].loc[:,[\"potential_pos_overall\", \"potential_neg_overall\", \"max_cap\"]]\n",
+    "    )\n",
+    "    df[\"max_potential\"] = df[[\"potential_pos_overall\", \"potential_neg_overall\"]].max(axis=1)\n",
+    "    df = df[[\"max_potential\", \"max_cap\"]]\n",
+    "    df[\"annual_invest_limit\"] = df.min(axis=1)\n",
+    "    df = df[[\"annual_invest_limit\"]]\n",
+    "    df = resample_timeseries(\n",
+    "        df, freq, aggregation_rule=\"sum\", interpolation_rule=\"ffill\"\n",
+    "    )[:-1]\n",
+    "    sinks_dr_el_ava_pos_ts_absolute[dr_cluster] = sinks_dr_el_ava_pos_ts[dr_cluster] * df[\"annual_invest_limit\"].values\n",
+    "    fig, ax = plt.subplots(figsize=(15, 5))\n",
+    "    _ = sinks_dr_el_ava_pos_ts_absolute[dr_cluster].plot(ax=ax)\n",
+    "    plt.title(dr_cluster)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9949ac84",
+   "metadata": {},
+   "source": [
+    "## Availabilty negative"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f0fda58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_dr_el_ava_neg_ts = input_data[\"sinks_dr_el_ava_neg_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1478a64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_dr_el_ava_neg_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15ec24b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(sinks_dr_el_ava_neg_ts[:8760])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "928d6de9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sinks_dr_el_ava_neg_ts_absolute = {}\n",
+    "for dr_cluster in dr_clusters.index:\n",
+    "    df = create_datetime_index(\n",
+    "        potential_parameters[dr_cluster].loc[:,[\"potential_pos_overall\", \"potential_neg_overall\", \"max_cap\"]]\n",
+    "    )\n",
+    "    df[\"max_potential\"] = df[[\"potential_pos_overall\", \"potential_neg_overall\"]].max(axis=1)\n",
+    "    df = df[[\"max_potential\", \"max_cap\"]]\n",
+    "    df[\"annual_invest_limit\"] = df.min(axis=1)\n",
+    "    df = df[[\"annual_invest_limit\"]]\n",
+    "    df = resample_timeseries(\n",
+    "        df, freq, aggregation_rule=\"sum\", interpolation_rule=\"ffill\"\n",
+    "    )[:-1]\n",
+    "    sinks_dr_el_ava_neg_ts_absolute[dr_cluster] = sinks_dr_el_ava_neg_ts[dr_cluster] * df[\"annual_invest_limit\"].values\n",
+    "    fig, ax = plt.subplots(figsize=(15, 5))\n",
+    "    _ = sinks_dr_el_ava_neg_ts_absolute[dr_cluster].plot(ax=ax)\n",
+    "    plt.title(dr_cluster)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d53f9d7",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1769,8 +2073,8 @@
    "title_sidebar": "Contents",
    "toc_cell": false,
    "toc_position": {
-    "height": "1117px",
-    "left": "37px",
+    "height": "1145px",
+    "left": "38px",
     "top": "111.125px",
     "width": "512px"
    },

--- a/invest_input_sanity_check.ipynb
+++ b/invest_input_sanity_check.ipynb
@@ -684,6 +684,67 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c9fa6363",
+   "metadata": {},
+   "source": [
+    "## Linking transformers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44d430bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linking_transformers = input_data[\"linking_transformers\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a5b25c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linking_transformers.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cb398b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linking_transformers.conversion_factor.unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cfe123f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linking_transformers.type.unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d68e2374",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linking_transformers_transposed = linking_transformers.drop(\n",
+    "    columns=[\"from\", \"to\", \"conversion_factor\", \"type\"]\n",
+    ").T.astype(\"float64\")\n",
+    "plot_time_series_cols(linking_transformers_transposed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5ff90071",
    "metadata": {},
    "source": [
@@ -1254,6 +1315,194 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0420a955",
+   "metadata": {},
+   "source": [
+    "### Fixed costs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8596c96b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_costs = input_data[\"fixed_costs\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47280915",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "fixed_costs.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0c2f292",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "fixed_costs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33210f9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_costs_absolute = pd.DataFrame(index=costs_investment.index, columns=costs_investment.columns)\n",
+    "for col in costs_investment.columns:\n",
+    "    fixed_costs_absolute[col] = costs_investment[col] * fixed_costs.loc[col].values[0]/100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ec36ea2",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "fixed_costs_absolute.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f476113",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(fixed_costs_absolute)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ddff209",
+   "metadata": {},
+   "source": [
+    "### Fixed costs storages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cb9e4b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_costs_storages = input_data[\"fixed_costs_storages\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9db429f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_costs_storages.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32414316",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_costs_storages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a6732c2",
+   "metadata": {},
+   "source": [
+    "#### Fixed costs for capacity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "249c1f0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_storages_investment_capacity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79fa0626",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_costs_storages_capacity_absolute = pd.DataFrame(\n",
+    "    index=costs_storages_investment_capacity.index, \n",
+    "    columns=costs_storages_investment_capacity.columns\n",
+    ")\n",
+    "for col in costs_storages_investment_capacity.columns:\n",
+    "    try:\n",
+    "        fixed_costs_storages_capacity_absolute[col] = (\n",
+    "            costs_storages_investment_capacity[col] * fixed_costs_storages.loc[col].values[0]/100\n",
+    "        )\n",
+    "    except KeyError:\n",
+    "        pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "630eb1c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_costs_storages_capacity_absolute.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0541634",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(fixed_costs_storages_capacity_absolute)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c89d862",
+   "metadata": {},
+   "source": [
+    "#### Fixed costs for power"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c179a3d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "a9735730",
    "metadata": {},
    "source": [
@@ -1292,9 +1541,201 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1e824871",
+   "metadata": {},
+   "source": [
+    "## Emission limits"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3655ac56",
+   "id": "47763fd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "emission_limits = input_data[\"emission_limits\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0a166d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "emission_limits.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e806240",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(emission_limits)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f04ccccb",
+   "metadata": {},
+   "source": [
+    "# Other data\n",
+    "## WACC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a791abed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wacc = input_data[\"wacc\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46b66bf1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wacc.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce76c187",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wacc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb4b3ed4",
+   "metadata": {},
+   "source": [
+    "## Interest rate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f4ee5a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interest_rate = input_data[\"interest_rate\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1be723a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interest_rate.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61dbc2e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interest_rate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32df9aa9",
+   "metadata": {},
+   "source": [
+    "## Hydrogen investment maxima"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d34bc945",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hydrogen_investment_maxima = input_data[\"hydrogen_investment_maxima\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "625d9863",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hydrogen_investment_maxima.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b5c246a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = hydrogen_investment_maxima.plot()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88aa0327",
+   "metadata": {},
+   "source": [
+    "## Emission development factors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3707c128",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "emission_development_factors = input_data[\"emission_development_factors\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2be29bdf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "emission_development_factors.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d934e8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(emission_development_factors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82f660b1",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1322,15 +1763,15 @@
    "base_numbering": 1,
    "nav_menu": {},
    "number_sections": true,
-   "sideBar": true,
+   "sideBar": false,
    "skip_h1_title": false,
    "title_cell": "Table of Contents",
    "title_sidebar": "Contents",
    "toc_cell": false,
    "toc_position": {
-    "height": "calc(100% - 180px)",
-    "left": "10px",
-    "top": "150px",
+    "height": "1117px",
+    "left": "37px",
+    "top": "111.125px",
     "width": "512px"
    },
    "toc_section_display": true,

--- a/invest_input_sanity_check.ipynb
+++ b/invest_input_sanity_check.ipynb
@@ -868,9 +868,433 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "468f1965",
+   "metadata": {},
+   "source": [
+    "### Exogenous max capacity\n",
+    "Development factors for exogenous maximum capacity of transformer clusters"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64fe6992",
+   "id": "90ef509b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transformers_exogenous_max_ts = input_data[\"transformers_exogenous_max_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61b551cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transformers_exogenous_max_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5bb68fbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(transformers_exogenous_max_ts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a9fa734",
+   "metadata": {},
+   "source": [
+    "## Linking transformers\n",
+    "### Hourly time series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea55b872",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linking_transformers_ts = input_data[\"linking_transformers_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5967c35b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linking_transformers_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1f503c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(linking_transformers_ts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d2fd16d",
+   "metadata": {},
+   "source": [
+    "### Annual time series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47ee1b18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linking_transformers_annual_ts = input_data[\"linking_transformers_annual_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56457bb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linking_transformers_annual_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74548568",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(linking_transformers_annual_ts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df2d5d8f",
+   "metadata": {},
+   "source": [
+    "## Costs\n",
+    "### Fuel costs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fff66471",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_fuel_ts = input_data[\"costs_fuel_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "328b0d60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_fuel_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1aa0323",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(costs_fuel_ts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87528ec7",
+   "metadata": {},
+   "source": [
+    "### Emissions costs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cfe790b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_emissions_ts = input_data[\"costs_emissions_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac4cae82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_emissions_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfc9d5bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = costs_emissions_ts.iloc[:,0].plot()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79a50626",
+   "metadata": {},
+   "source": [
+    "### Costs operation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c3e821d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_operation_ts = input_data[\"costs_operation_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "383c3f58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_operation_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cb08e74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(costs_operation_ts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85071f3c",
+   "metadata": {},
+   "source": [
+    "### Costs operation storages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d163c795",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_operation_storages_ts = input_data[\"costs_operation_storages_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "654fd595",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_operation_storages_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7323b83e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(costs_operation_storages_ts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "237ad65a",
+   "metadata": {},
+   "source": [
+    "### Costs investment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34edb001",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_investment = input_data[\"costs_investment\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43e011c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_investment.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d1e18d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(costs_investment)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5eda8c05",
+   "metadata": {},
+   "source": [
+    "### Costs storages investment\n",
+    "#### investment in capacity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4f053c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_storages_investment_capacity = input_data[\"costs_storages_investment_capacity\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a140f7d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_storages_investment_capacity.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2042b245",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(costs_storages_investment_capacity)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36b32ec5",
+   "metadata": {},
+   "source": [
+    "#### investment in power"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47ce0331",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_storages_investment_power = input_data[\"costs_storages_investment_power\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6075be35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "costs_storages_investment_power.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "493aa12d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(costs_storages_investment_power)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9735730",
+   "metadata": {},
+   "source": [
+    "## Storages\n",
+    "### Exocenous maximum capacity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f68f36b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "storages_el_exogenous_max_ts = input_data[\"storages_el_exogenous_max_ts\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d75a3ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "storages_el_exogenous_max_ts.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7409ef1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_time_series_cols(storages_el_exogenous_max_ts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3655ac56",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/investment_model_dispatch_inspection.ipynb
+++ b/investment_model_dispatch_inspection.ipynb
@@ -126,8 +126,8 @@
     "plt.rcParams.update({'font.size': 12})\n",
     "rounding_precision = 2\n",
     "\n",
-    "start_time_step = \"2020-01-01 00:00:00\"\n",
-    "time_steps_to_be_considered_in_hours = 168 * 4\n",
+    "start_time_step = \"2040-01-01 00:00:00\"\n",
+    "time_steps_to_be_considered_in_hours = 168 * 12\n",
     "amount_of_time_steps = time_steps_to_be_considered_in_hours / int(frequency.split(\"H\")[0])"
    ]
   },
@@ -260,7 +260,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(20, 10))\n",
-    "export_pattern[-100:].plot(kind=\"area\", stacked=True, ax=ax)\n",
+    "export_pattern.plot(kind=\"area\", stacked=True, ax=ax)\n",
     "plt.show()"
    ]
   },
@@ -272,7 +272,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(20, 10))\n",
-    "import_pattern[-100:].plot(kind=\"area\", stacked=True, ax=ax)\n",
+    "import_pattern.plot(kind=\"area\", stacked=True, ax=ax)\n",
     "plt.show()"
    ]
   },
@@ -283,9 +283,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(20, 10))\n",
-    "demand_pattern[:300000].plot(kind=\"area\", stacked=True, ax=ax)\n",
+    "if dr_scenario != \"none\":\n",
+    "    fig, ax = plt.subplots(len(demand_pattern.columns), figsize=(16, 8 * len(demand_pattern.columns)))\n",
+    "    for i, col in enumerate(demand_pattern.columns):\n",
+    "        demand_pattern[col].plot(kind=\"area\", stacked=True, ax=ax[i])\n",
+    "        ax[i].legend(loc=\"best\")\n",
+    "    plt.show()\n",
+    "\n",
+    "else:\n",
+    "    fig, ax = plt.subplots(figsize=(16, 8))\n",
+    "    demand_pattern.plot(kind=\"area\", ax=ax)\n",
+    "    plt.show()                           "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c16b37b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(16, 8))\n",
+    "demand_pattern.plot(kind=\"area\", stacked=True, ax=ax)\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51f2aa67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demand_pattern.max()"
    ]
   },
   {
@@ -356,6 +386,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e9c47d68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_time_step=\"2040-03-15 00:00:00\"\n",
+    "amount_of_time_steps=168 * 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f65875de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colors = {\n",
+    "    **LOAD, \n",
+    "    **{\n",
+    "        f\"{cluster}_demand_after\": value for cluster, value in DEMAND_RESPONSE_CLUSTERS.items()\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "plot_single_dispatch_pattern(\n",
+    "    demand_pattern,\n",
+    "    start_time_step,\n",
+    "    amount_of_time_steps,\n",
+    "    colors,\n",
+    "    save=True,\n",
+    "    path_plots=\"./plots/\",\n",
+    "    filename=\"demand_pattern\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "30f2c6bd",
    "metadata": {},
    "outputs": [],
@@ -407,12 +473,13 @@
     "\n",
     "plot_single_dispatch_pattern(\n",
     "    shortage_excess_pattern,\n",
-    "    start_time_step,\n",
-    "    amount_of_time_steps,\n",
+    "    \"2020-01-01 00:00:00\",\n",
+    "    227758,\n",
     "    colors,\n",
     "    save=True,\n",
     "    path_plots=\"./plots/\",\n",
     "    filename=\"shortage_excess_pattern\",\n",
+    "    kind=\"line\"\n",
     ")"
    ]
   },
@@ -474,12 +541,23 @@
     "plot_single_dispatch_pattern(\n",
     "    demand_response_pattern[[col for col in demand_response_pattern.columns if not \"dsm_do_shed\" in col]],\n",
     "    start_time_step,\n",
-    "    amount_of_time_steps,\n",
+    "    200,\n",
     "    colors,\n",
     "    save=True,\n",
     "    path_plots=\"./plots/\",\n",
     "    filename=\"demand_response_pattern\",\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "412dfaba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demand_response_pattern.loc[\"2040-03-12 22:00\":\"2040-03-13 21:00\", \n",
+    "                            [\"ind_cluster_shift_only_dsm_do_shift\", \"ind_cluster_shift_only_dsm_up\"]]"
    ]
   },
   {

--- a/investment_model_dispatch_inspection.ipynb
+++ b/investment_model_dispatch_inspection.ipynb
@@ -260,7 +260,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(20, 10))\n",
-    "export_pattern[:30000].plot(kind=\"area\", stacked=True, ax=ax)\n",
+    "export_pattern[-100:].plot(kind=\"area\", stacked=True, ax=ax)\n",
     "plt.show()"
    ]
   },
@@ -272,7 +272,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(20, 10))\n",
-    "import_pattern[:30000].plot(kind=\"area\", stacked=True, ax=ax)\n",
+    "import_pattern[-100:].plot(kind=\"area\", stacked=True, ax=ax)\n",
     "plt.show()"
    ]
   },
@@ -286,15 +286,6 @@
     "fig, ax = plt.subplots(figsize=(20, 10))\n",
     "demand_pattern[:300000].plot(kind=\"area\", stacked=True, ax=ax)\n",
     "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "86503a07",
-   "metadata": {},
-   "source": [
-    "> **Conclusions**\n",
-    "> * There seems to be something off with exports and imports ... -> strong year to year variation for 2021 compared to 2020."
    ]
   },
   {
@@ -330,6 +321,16 @@
     "    path_plots=\"./plots/\",\n",
     "    filename=\"demand_pattern\",\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de1945cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demand_pattern.describe()"
    ]
   },
   {

--- a/investment_model_dispatch_inspection.ipynb
+++ b/investment_model_dispatch_inspection.ipynb
@@ -47,9 +47,9 @@
    "outputs": [],
    "source": [
     "# Model configuration\n",
-    "time_frame_in_years = 1\n",
-    "frequency = \"24H\"\n",
-    "dr_scenario = \"50\"\n",
+    "time_frame_in_years = 26\n",
+    "frequency = \"1H\"\n",
+    "dr_scenario = \"none\"\n",
     "dr_scenarios = [\"none\", \"5\", \"50\", \"95\"]\n",
     "\n",
     "# Paths, filenames and color codes\n",
@@ -232,6 +232,69 @@
    "outputs": [],
    "source": [
     "generators_pattern.sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c003fc55",
+   "metadata": {},
+   "source": [
+    "## Inspect some long-term results\n",
+    "* Exports and imports patterns\n",
+    "* Demand"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0844c47",
+   "metadata": {},
+   "source": [
+    "### Exports and imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d9f12b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(20, 10))\n",
+    "export_pattern[:30000].plot(kind=\"area\", stacked=True, ax=ax)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69420581",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(20, 10))\n",
+    "import_pattern[:30000].plot(kind=\"area\", stacked=True, ax=ax)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fad70891",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(20, 10))\n",
+    "demand_pattern[:300000].plot(kind=\"area\", stacked=True, ax=ax)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86503a07",
+   "metadata": {},
+   "source": [
+    "> **Conclusions**\n",
+    "> * There seems to be something off with exports and imports ... -> strong year to year variation for 2021 compared to 2020."
    ]
   },
   {
@@ -456,7 +519,7 @@
    "toc_cell": false,
    "toc_position": {},
    "toc_section_display": true,
-   "toc_window_display": false
+   "toc_window_display": true
   },
   "varInspector": {
    "cols": {

--- a/investment_results_inspection.ipynb
+++ b/investment_results_inspection.ipynb
@@ -59,7 +59,7 @@
     "# Model configuration\n",
     "time_frame_in_years = 26\n",
     "frequency = \"1H\"\n",
-    "dr_scenario = \"none\"\n",
+    "dr_scenario = \"50\"\n",
     "dr_scenarios = [\"none\", \"5\", \"50\", \"95\"]\n",
     "\n",
     "# Paths, filenames and color codes\n",
@@ -191,7 +191,8 @@
     "    filename=\"results_invest_dr_scenario\",\n",
     "    dr_scenario=dr_scenario,\n",
     "    path_plots=path_plots,\n",
-    "    path_data_out=path_processed_data\n",
+    "    path_data_out=path_processed_data,\n",
+    "    ylim=[0, 20000]\n",
     ")"
    ]
   },
@@ -348,6 +349,7 @@
     "backup_generation = pd.read_csv(\n",
     "    f\"{path_processed_data}{filename_backup}\", index_col=0\n",
     ")\n",
+    "backup_generation = backup_generation.loc[:2045]\n",
     "backup_generation.index = backup_generation.index.astype(str)"
    ]
   },
@@ -403,8 +405,19 @@
     "    filename=\"results_all_dr_scenario\",\n",
     "    dr_scenario=dr_scenario,\n",
     "    path_plots=path_plots,\n",
-    "    path_data_out=path_processed_data\n",
+    "    path_data_out=path_processed_data,\n",
+    "    ylim=[0, 170000]\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "439662dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overall_capacity"
    ]
   },
   {
@@ -694,7 +707,7 @@
     "height": "calc(100% - 180px)",
     "left": "10px",
     "top": "150px",
-    "width": "376.766px"
+    "width": "165px"
    },
    "toc_section_display": true,
    "toc_window_display": true

--- a/investment_results_inspection.ipynb
+++ b/investment_results_inspection.ipynb
@@ -57,8 +57,8 @@
    "outputs": [],
    "source": [
     "# Model configuration\n",
-    "time_frame_in_years = 31\n",
-    "frequency = \"8H\"\n",
+    "time_frame_in_years = 26\n",
+    "frequency = \"1H\"\n",
     "dr_scenario = \"none\"\n",
     "dr_scenarios = [\"none\", \"5\", \"50\", \"95\"]\n",
     "\n",

--- a/pommesevaluation/amiris_input_sanity_check.py
+++ b/pommesevaluation/amiris_input_sanity_check.py
@@ -1,0 +1,117 @@
+import pandas as pd
+from matplotlib import pyplot as plt
+import os
+
+
+def check_time_series(path_folder, file_name, plot=True):
+    """Routine to check time series data
+
+    Parameters
+    ----------
+    path_folder: str
+        Path where file is located
+    file_name: str
+        File name of time series to be checked
+    plot: bool
+        If True, show a plot
+
+    Returns
+    -------
+    stats: pd.DataFrame
+        Parameter statistics from describe method
+    """
+    time_series = pd.read_csv(
+        f"{path_folder}{file_name}", sep=";", header=None, index_col=0
+    ).astype("float64")
+    stats = time_series.describe()
+    if plot:
+        fig, ax = plt.subplots(figsize=(15, 5))
+        time_series.plot(ax=ax)
+        plt.legend(labels=[file_name])
+        plt.tight_layout()
+        plt.show()
+
+    return stats
+
+
+def check_time_series_chunks(
+    path_folder, file_name, chunks="annual", plot=True
+):
+    """Routine to check time series data chunks
+
+    Parameters
+    ----------
+    path_folder: str
+        Path where file is located
+    file_name: str
+        File name of time series to be checked
+    chunks: str
+        Chunks of data to be checked (only "annual" is allowed)
+    plot: bool
+        If True, show a plot of data
+    """
+    time_series = pd.read_csv(
+        f"{path_folder}{file_name}", sep=";", header=None, index_col=0
+    )
+    years = time_series.index.str.slice(start=0, stop=4).unique()
+    annual_data = {}
+    if chunks == "annual":
+        for iter_year in years:
+            annual_data[iter_year] = {}
+            annual_data[iter_year]["data"] = time_series.loc[
+                time_series.index.str.slice(start=0, stop=4) == iter_year
+            ]
+            annual_data[iter_year]["stats"] = annual_data[iter_year][
+                "data"
+            ].describe()
+    if plot:
+        plot_time_series(annual_data)
+    else:
+        raise ValueError("Chunks other than annual are not implemented, yet.")
+
+    return annual_data
+
+
+def plot_time_series(data):
+    """Plot given time series"
+
+    Parameters
+    ----------
+    data: dict
+        Dictionary holding annual data
+    """
+    fig, axs = plt.subplots(
+        nrows=len(data), ncols=1, figsize=(10, 5 * len(data))
+    )
+    for no, data_entries in enumerate(data.items()):
+        iter_year = data_entries[0]
+        time_series = data_entries[1]["data"]
+        time_series.plot(ax=axs[no])
+        axs[no].title.set_text(iter_year)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def get_all_csv_files_in_folder_except(path_folder, exception=None):
+    """Return a list of all csv files in folder except list of exceptions
+
+    Parameters
+    ----------
+    path_folder: str
+        Folder where csv files are stored
+    exception: list of str
+        Files to ignore
+
+    Returns
+    -------
+    list:
+        List of all csv files in given folder
+    """
+    if not exception:
+        exception = []
+    return [
+        file
+        for file in os.listdir(path_folder)
+        if file.endswith(".csv") and file not in exception
+    ]

--- a/pommesevaluation/investment_results_inspection.py
+++ b/pommesevaluation/investment_results_inspection.py
@@ -218,6 +218,7 @@ def plot_single_investment_variable(
     dr_scenario="none",
     path_plots="./plots/",
     path_data_out="./data_out/",
+    ylim=None,
 ):
     """Plot a single investment-related variable from results data set
 
@@ -259,6 +260,9 @@ def plot_single_investment_variable(
 
     path_data_out : str
         Path for storing the aggregated results data
+
+    ylim : list
+        y axis limits
     """
     ylabels = {
         "invest": "newly invested capacity",
@@ -274,7 +278,7 @@ def plot_single_investment_variable(
         plot_data = results.copy()
 
     fig, ax = plt.subplots(figsize=(12, 5))
-    create_single_plot(plot_data, variable_name, colors, storage, ax, ylabels)
+    create_single_plot(plot_data, variable_name, colors, storage, ax, ylabels, ylim=ylim)
 
     _ = plt.tight_layout()
 

--- a/pommesevaluation/investment_results_inspection.py
+++ b/pommesevaluation/investment_results_inspection.py
@@ -2,6 +2,7 @@
 Routines used for investment results inspection for both, analyses of
 investments taken as well as the resulting dispatch of units resp. clusters.
 """
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -616,9 +617,24 @@ def plot_time_series_cols(df, size=(15, 5)):
     )
 
     for no, col in enumerate(df.columns):
-        _ = df[col].plot(ax=axs[no])
-        _ = axs[no].set_title(col)
+        try:
+            _ = df[col].plot(ax=axs[no])
+            _ = axs[no].set_title(col)
+        except TypeError:
+            warnings.warn(
+                f"No numeric data to plot for column: {col}", UserWarning
+            )
 
     _ = plt.tight_layout()
     _ = plt.show()
     plt.close()
+
+
+def create_datetime_index(df: pd.DataFrame) -> pd.DataFrame:
+    """Return DataFrame with datetime index"""
+    df.loc[2051] = df.iloc[-1]
+    df["new_index"] = df.index.astype(str) + "-01-01"
+    df.index = pd.to_datetime(df["new_index"])
+    df.drop(columns="new_index", inplace=True)
+
+    return df

--- a/pommesevaluation/investment_results_inspection.py
+++ b/pommesevaluation/investment_results_inspection.py
@@ -278,7 +278,9 @@ def plot_single_investment_variable(
         plot_data = results.copy()
 
     fig, ax = plt.subplots(figsize=(12, 5))
-    create_single_plot(plot_data, variable_name, colors, storage, ax, ylabels, ylim=ylim)
+    create_single_plot(
+        plot_data, variable_name, colors, storage, ax, ylabels, ylim=ylim
+    )
 
     _ = plt.tight_layout()
 
@@ -589,8 +591,34 @@ def plot_single_dispatch_pattern(
         file_name_out = file_name_out.replace(":", "-").replace(" ", "_")
         file_name_out.replace(":", "-")
         _ = plt.savefig(
-            file_name_out, dpi=300,
+            file_name_out,
+            dpi=300,
         )
 
+    _ = plt.show()
+    plt.close()
+
+
+def plot_time_series_cols(df, size=(15, 5)):
+    """Plot each column of a time series DataFrame in dedicated subplot
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        time series data to visualize
+
+    size: tuple of int
+        size of plot; first entry: width; second entry: height of single
+        subplot
+    """
+    fig, axs = plt.subplots(
+        len(df.columns), 1, figsize=(size[0], len(df.columns) * size[1])
+    )
+
+    for no, col in enumerate(df.columns):
+        _ = df[col].plot(ax=axs[no])
+        _ = axs[no].set_title(col)
+
+    _ = plt.tight_layout()
     _ = plt.show()
     plt.close()

--- a/pommesevaluation/investment_results_inspection.py
+++ b/pommesevaluation/investment_results_inspection.py
@@ -535,6 +535,7 @@ def plot_single_dispatch_pattern(
     save=True,
     path_plots="./plots/",
     filename="dispatch_pattern",
+    kind="area",
 ):
     """Plot a single dispatch pattern for a given start and end time stamp
 
@@ -560,6 +561,9 @@ def plot_single_dispatch_pattern(
 
     filename : str
         File name to use for the plot
+
+    kind : str
+        Kind of plot to draw; defaults to "area"
     """
     index_start = int(dispatch_pattern.index.get_loc(start_time_step))
     index_end = int(index_start + amount_of_time_steps + 1)
@@ -567,7 +571,7 @@ def plot_single_dispatch_pattern(
 
     fig, ax = plt.subplots(figsize=(15, 10))
     _ = dispatch_pattern.iloc[index_start:index_end].plot(
-        ax=ax, kind="area", color=colors
+        ax=ax, kind=kind, color=colors
     )
     _ = ax.set_xlabel("Time")
     _ = ax.set_ylabel("Energy [MWh/h]")

--- a/pommesevaluation/pommesinvest_routines.py
+++ b/pommesevaluation/pommesinvest_routines.py
@@ -1,4 +1,7 @@
+from typing import Dict
+
 import pandas as pd
+from pandas.tseries.frequencies import to_offset
 
 
 class InvestmentModelDummy:
@@ -12,6 +15,14 @@ class InvestmentModelDummy:
         end_time,
         overlap_in_time_steps,
         freq,
+        fuel_cost_pathway,
+        fuel_price_shock,
+        emissions_cost_pathway,
+        flexibility_options_scenario,
+        activate_emissions_pathway_limit,
+        activate_emissions_budget_limit,
+        activate_demand_response,
+        demand_response_scenario,
     ):
         """Initialize a data container"""
         self.path_folder_input = path_folder_input
@@ -20,6 +31,26 @@ class InvestmentModelDummy:
         self.end_time = end_time
         self.overlap_in_time_steps = overlap_in_time_steps
         self.freq = freq
+        self.fuel_cost_pathway = fuel_cost_pathway
+        self.fuel_price_shock = fuel_price_shock
+        self.emissions_cost_pathway = emissions_cost_pathway
+        self.flexibility_options_scenario = flexibility_options_scenario
+        self.activate_emissions_pathway_limit = (
+            activate_emissions_pathway_limit
+        )
+        self.activate_emissions_budget_limit = activate_emissions_budget_limit
+        self.activate_demand_response = activate_demand_response
+        self.demand_response_scenario = demand_response_scenario
+
+    def add_demand_response_clusters(self, demand_response_clusters):
+        """Append the information on demand response clusters to the model
+
+        Parameters
+        ----------
+        demand_response_clusters : list
+            Demand response clusters to be considered
+        """
+        setattr(self, "demand_response_clusters", demand_response_clusters)
 
 
 def load_input_data(filename=None, im=None):
@@ -98,3 +129,284 @@ def load_time_series_data_slice(filename=None, im=None):
         skiprows=range(1, start_index),
         nrows=end_index - start_index + 1,
     )
+
+
+def process_input_data(im: InvestmentModelDummy) -> Dict[str, pd.DataFrame]:
+    """Process and return input data
+
+    Parameters
+    ----------
+    im : InvestmentModelDummy
+        investment model (attributes)
+
+    Returns
+    -------
+    input_data : dict
+        Input data stored in a dict of pd.DataFrame
+    """
+    buses = {"buses": "buses"}
+
+    components = {
+        "sinks_excess": "sinks_excess",
+        "sinks_demand_el": "sinks_demand_el",
+        "sources_shortage": "sources_shortage",
+        "sources_commodity": "sources_commodity",
+        "sources_renewables": "sources_renewables_investment_model",
+        "exogenous_storages_el": "storages_el_exogenous",
+        "new_built_storages_el": "storages_el_investment_options",
+        "exogenous_transformers": "transformers_exogenous",
+        "new_built_transformers": "transformers_investment_options",
+    }
+
+    hourly_time_series = {
+        "sinks_demand_el_ts": "sinks_demand_el_ts_hourly",
+        "sources_renewables_ts": "sources_renewables_ts_hourly",
+        "transformers_minload_ts": "transformers_minload_ts_hourly",
+        "transformers_availability_ts": "transformers_availability_ts_hourly",
+        "linking_transformers_ts": "linking_transformers_ts",
+    }
+
+    annual_time_series = {
+        "transformers_exogenous_max_ts": "transformers_exogenous_max_ts",
+        "costs_fuel_ts": (
+            f"costs_fuel_{im.fuel_cost_pathway}_"
+            f"{im.fuel_price_shock}_nominal_indexed_ts"
+        ),
+        "costs_emissions_ts": (
+            f"costs_emissions_{im.emissions_cost_pathway}_nominal_indexed_ts"
+        ),
+        "costs_operation_ts": (
+            f"variable_costs_{im.flexibility_options_scenario}%_nominal"
+        ),
+        "costs_operation_storages_ts": (
+            f"variable_costs_storages_"
+            f"{im.flexibility_options_scenario}%_nominal"
+        ),
+        "costs_investment": (
+            f"investment_expenses_{im.flexibility_options_scenario}%_nominal"
+        ),
+        "costs_storages_investment_capacity": (
+            f"investment_expenses_storages_capacity_"
+            f"{im.flexibility_options_scenario}%_nominal"
+        ),
+        "costs_storages_investment_power": (
+            f"investment_expenses_storages_power_"
+            f"{im.flexibility_options_scenario}%_nominal"
+        ),
+        "linking_transformers_annual_ts": "linking_transformers_annual_ts",
+        "storages_el_exogenous_max_ts": "storages_el_exogenous_max_ts",
+    }
+
+    # Time-invariant data sets
+    other_files = {
+        "emission_limits": "emission_limits",
+        "wacc": "wacc",
+        "interest_rate": "interest_rate",
+        "fixed_costs": (
+            f"fixed_costs_{im.flexibility_options_scenario}%_nominal"
+        ),
+        "fixed_costs_storages": (
+            f"fixed_costs_storages_{im.flexibility_options_scenario}%_nominal"
+        ),
+        "hydrogen_investment_maxima": "hydrogen_investment_maxima",
+        "linking_transformers": "linking_transformers",
+    }
+
+    # Development factors for emissions; used for scaling minimum loads
+    if (
+        im.activate_emissions_pathway_limit
+        or im.activate_emissions_budget_limit
+    ):
+        other_files[
+            "emission_development_factors"
+        ] = "emission_development_factors"
+
+    # Add demand response units
+    if im.activate_demand_response:
+        # Overall demand = overall demand excluding demand response baseline
+        hourly_time_series["sinks_demand_el_ts"] = (
+            f"sinks_demand_el_excl_demand_response_ts_"
+            f"{im.demand_response_scenario}_hourly"
+        )
+        components[
+            "sinks_demand_el"
+        ] = f"sinks_demand_el_excl_demand_response_{im.demand_response_scenario}"
+
+        # Obtain demand response clusters from file to avoid hard-coding
+        components[
+            "demand_response_clusters_eligibility"
+        ] = "demand_response_clusters_eligibility"
+        dr_clusters = load_input_data(
+            filename="demand_response_clusters_eligibility", im=im
+        )
+        # Add demand response clusters information to the model itself
+        im.add_demand_response_clusters(list(dr_clusters.index))
+        for dr_cluster in dr_clusters.index:
+            components[
+                f"sinks_dr_el_{dr_cluster}"
+            ] = f"{dr_cluster}_potential_parameters_{im.demand_response_scenario}%"
+            annual_time_series[
+                f"sinks_dr_el_{dr_cluster}_variable_costs"
+            ] = f"{dr_cluster}_variable_costs_parameters_{im.demand_response_scenario}%"
+            annual_time_series[
+                f"sinks_dr_el_{dr_cluster}_fixed_costs_and_investments"
+            ] = (
+                f"{dr_cluster}_fixed_costs_and_investments_parameters_"
+                f"{im.demand_response_scenario}%"
+            )
+
+        hourly_time_series[
+            "sinks_dr_el_ts"
+        ] = f"sinks_demand_response_el_ts_{im.demand_response_scenario}"
+
+        hourly_time_series[
+            "sinks_dr_el_ava_pos_ts"
+        ] = f"sinks_demand_response_el_ava_pos_ts_{im.demand_response_scenario}"
+        hourly_time_series[
+            "sinks_dr_el_ava_neg_ts"
+        ] = f"sinks_demand_response_el_ava_neg_ts_{im.demand_response_scenario}"
+
+    # Combine all files
+    input_files = {
+        **buses,
+        **components,
+        **annual_time_series,
+        **hourly_time_series,
+    }
+    input_files = {**input_files, **other_files}
+
+    input_data = {
+        key: load_input_data(filename=name, im=im)
+        for key, name in input_files.items()
+    }
+
+    return input_data
+
+
+def resample_timeseries(
+    timeseries, freq, aggregation_rule="sum", interpolation_rule="linear"
+):
+    """Resample a timeseries to the frequency provided
+
+    The frequency of the given timeseries is determined at first and upsampling
+    resp. downsampling are carried out afterwards. For upsampling linear
+    interpolation (default) is used, but another method may be chosen.
+
+    Time series indices ignore time shifts and can be interpreted as UTC time.
+    Since they aren't localized, this cannot be detected by pandas and the
+    correct frequency cannot be inferred. As a hack, only the first couple of
+    time steps are checked, for which no problems should occur.
+
+    Parameters
+    ----------
+    timeseries : :obj:`pd.DataFrame`
+        The timeseries to be resampled stored in a pd.DataFrame
+
+    freq : :obj:`str`
+        The target frequency
+
+    interpolation_rule : :obj:`str`
+        Method used for interpolation in upsampling
+
+    Returns
+    -------
+    resampled_timeseries : :obj:`pd.DataFrame`
+        The resampled timeseries stored in a pd.DataFrame
+
+    """
+    # Ensure a datetime index
+    try:
+        timeseries.index = pd.DatetimeIndex(timeseries.index)
+    except ValueError:
+        raise ValueError(
+            "Time series has an invalid index. "
+            "A pd.DatetimeIndex is required."
+        )
+
+    try:
+        original_freq = pd.infer_freq(timeseries.index, warn=True)
+    except ValueError:
+        original_freq = "AS"
+
+    # Hack for problems with recognizing abolishing the time shift
+    if not original_freq:
+        try:
+            original_freq = pd.infer_freq(timeseries.index[:5], warn=True)
+        except ValueError:
+            raise ValueError("Cannot detect frequency of time series!")
+
+    # Introduce common timestamp to be able to compare different frequencies
+    common_dt = pd.to_datetime("2000-01-01")
+
+    if common_dt + to_offset(freq) > common_dt + to_offset(original_freq):
+        # do downsampling
+        resampled_timeseries = timeseries.resample(freq).agg(aggregation_rule)
+
+    else:
+        # do upsampling
+        resampled_timeseries = timeseries.resample(freq).interpolate(
+            method=interpolation_rule
+        )
+
+    cut_leap_days(resampled_timeseries)
+
+    return resampled_timeseries
+
+
+def cut_leap_days(time_series):
+    """Take a time series index with real dates and cut the leap days out
+
+    Actual time stamps cannot be interpreted. Instead consider 8760 hours
+    of a synthetical year
+
+    Parameters
+    ----------
+    time_series : pd.Series or pd.DataFrame
+        original time series with real life time index
+
+    Returns
+    -------
+    time_series : pd.Series or pd.DataFrame
+        Time series, simply cutted down to 8 760 hours per year
+    """
+    years = sorted(list(set(getattr(time_series.index, "year"))))
+    for year in years:
+        if is_leap_year(year):
+            try:
+                time_series.drop(
+                    time_series.loc[
+                        (time_series.index.year == year)
+                        & (time_series.index.month == 12)
+                        & (time_series.index.day == 31)
+                    ].index,
+                    inplace=True,
+                )
+            except KeyError:
+                continue
+
+    return time_series
+
+
+def is_leap_year(year):
+    """Check whether given year is a leap year or not
+
+    Parameters:
+    -----------
+    year: :obj:`int`
+        year which shall be checked
+
+    Returns:
+    --------
+    leap_year: :obj:`boolean`
+        True if year is a leap year and False else
+    """
+    leap_year = False
+
+    if year % 4 == 0:
+        leap_year = True
+    if year % 100 == 0:
+        leap_year = False
+    if year % 400 == 0:
+        leap_year = True
+
+    return leap_year

--- a/pommesevaluation/pommesinvest_routines.py
+++ b/pommesevaluation/pommesinvest_routines.py
@@ -1,0 +1,100 @@
+import pandas as pd
+
+
+class InvestmentModelDummy:
+    """Container object holding attributes, an InvestmentModel usually has"""
+
+    def __init__(
+        self,
+        path_folder_input,
+        countries,
+        start_time,
+        end_time,
+        overlap_in_time_steps,
+        freq,
+    ):
+        """Initialize a data container"""
+        self.path_folder_input = path_folder_input
+        self.countries = countries
+        self.start_time = start_time
+        self.end_time = end_time
+        self.overlap_in_time_steps = overlap_in_time_steps
+        self.freq = freq
+
+
+def load_input_data(filename=None, im=None):
+    r"""Load input data from csv files.
+
+    Parameters
+    ----------
+    filename : :obj:`str`
+        Name of CSV file containing data
+
+    im : :class:`InvestmentModel`
+        The investment model that is considered
+
+    Returns
+    -------
+    df : :class:`pandas.DataFrame`
+        DataFrame containing information about nodes or time series.
+    """
+    if "ts_hourly" not in filename:
+        df = pd.read_csv(im.path_folder_input + filename + ".csv", index_col=0)
+    # Load slices for hourly data to reduce computational overhead
+    else:
+        df = load_time_series_data_slice(filename + ".csv", im)
+
+    if "country" in df.columns and im.countries is not None:
+        df = df[df["country"].isin(im.countries)]
+
+    if df.isna().any().any() and "_ts" in filename:
+        print(
+            f"Attention! Time series input data file {filename} contains NaNs."
+        )
+        print(df.loc[df.isna().any(axis=1)])
+
+    return df
+
+
+def load_time_series_data_slice(filename=None, im=None):
+    """Load slice of input time series data from csv files.
+
+    Determine index range to read in from reading in index
+    separately.
+
+    Parameters
+    ----------
+    filename : :obj:`str`
+        Name of CSV file containing data
+
+    im : :class:`InvestmentModel`
+        The investment model that is considered
+
+    Returns
+    -------
+    df : :class:`pandas.DataFrame`
+        DataFrame containing sliced time series.
+    """
+    time_series_start = pd.read_csv(
+        im.path_folder_input + filename,
+        parse_dates=True,
+        index_col=0,
+        usecols=[0],
+    )
+    start_index = pd.Index(time_series_start.index).get_loc(im.start_time)
+    time_series_end = pd.Timestamp(im.end_time)
+    end_index = pd.Index(time_series_start.index).get_loc(
+        (
+            time_series_end
+            + im.overlap_in_time_steps
+            * pd.Timedelta(hours=int(im.freq.split("H")[0]))
+        ).strftime("%Y-%m-%d %H:%M:%S")
+    )
+
+    return pd.read_csv(
+        im.path_folder_input + filename,
+        parse_dates=True,
+        index_col=0,
+        skiprows=range(1, start_index),
+        nrows=end_index - start_index + 1,
+    )


### PR DESCRIPTION
This introduces a sanity checking routines for all model inputs provided to the investment model *pommesinvest* and prepared with *pommesdata* for that purpose.