### PR TITLE
Correct output path in AMIRIS converter

### DIFF
--- a/amiris_converter.ipynb
+++ b/amiris_converter.ipynb
@@ -724,7 +724,7 @@
     "    grouped_plants_unclustered,\n",
     "    plot=False,\n",
     "    filename_suffix=\"_unclustered\",\n",
-    "    path=f\"{path_processed_outputs}{sub_path_outputs}all_scenarios/\",\n",
+    "    path=f\"{path_processed_outputs}{sub_path_outputs}\",\n",
     ")"
    ]
   },
@@ -738,7 +738,7 @@
     "perform_efficiency_regression(\n",
     "    grouped_plants,\n",
     "    plot=False,\n",
-    "    path=f\"{path_processed_outputs}{sub_path_outputs}all_scenarios/\",\n",
+    "    path=f\"{path_processed_outputs}{sub_path_outputs}\",\n",
     ")"
    ]
   },


### PR DESCRIPTION
Adjust output path for efficiency regression since sub path is already considered in function definition